### PR TITLE
Streaming VM: Implement bytecode streaming support and related tests.

### DIFF
--- a/cmake/demo.cmake
+++ b/cmake/demo.cmake
@@ -48,3 +48,20 @@ add_custom_target(copy_compiler_to_led_matrix_demo ALL
     COMMENT "Copying smollu_compiler to demo directory"
     DEPENDS smollu_compiler
 )
+
+# Compile demo.smol to demo.smolbc for testing
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/demo/Simple\ demo/demo.smolbc
+    COMMAND $<TARGET_FILE:smollu_compiler>
+            "${CMAKE_BINARY_DIR}/demo/Simple demo/demo.smol"
+            -o
+            "${CMAKE_BINARY_DIR}/demo/Simple demo/demo.smolbc"
+    DEPENDS smollu_compiler ${CMAKE_BINARY_DIR}/demo/Simple\ demo/demo.smol
+    COMMENT "Compiling demo.smol to demo.smolbc"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+# Create a target that ensures demo bytecode is compiled
+add_custom_target(compile_demo_bytecode ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/demo/Simple\ demo/demo.smolbc
+)

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -2,14 +2,28 @@
 
 include(CTest)
 option(BUILD_TESTS "Build unit tests" ON)
+option(BUILD_STREAMING_TEST "Build streaming VM test" ON)
 
 # Register tests at the top level to ensure CTest finds them
 if(BUILD_TESTS)
     # VM tests
     add_test(NAME vm_tests COMMAND vm/test_smollu_vm --verbose)
-    
-    # Compiler tests  
+
+    # Compiler tests
     add_test(NAME lexer_tests COMMAND compiler/test_smollu_lexer --verbose)
     add_test(NAME parser_tests COMMAND compiler/test_smollu_parser --verbose)
     add_test(NAME bytecode_codegen_tests COMMAND compiler/test_smollu_bytecode_codegen --verbose)
+endif()
+
+# Streaming VM test (requires bytecode file)
+if(BUILD_STREAMING_TEST)
+    add_test(NAME streaming_vm_test
+             COMMAND vm/test_streaming_vm ${CMAKE_BINARY_DIR}/demo/Simple\ demo/demo.smolbc
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+    # This test depends on demo bytecode being compiled
+    # Note: Using FIXTURES_REQUIRED would be better, but DEPENDS works for build-time dependencies
+    set_tests_properties(streaming_vm_test PROPERTIES
+        REQUIRED_FILES ${CMAKE_BINARY_DIR}/demo/Simple\ demo/demo.smolbc
+    )
 endif()

--- a/vm/CMakeLists.txt
+++ b/vm/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(smollu_vm PUBLIC
 
 # VM Tests
 option(BUILD_TESTS "Build unit tests" ON)
+option(BUILD_STREAMING_TEST "Build streaming VM test" ON)
 
 if(BUILD_TESTS)
     find_package(PkgConfig REQUIRED)
@@ -34,4 +35,30 @@ if(BUILD_TESTS)
     target_link_directories(test_smollu_vm PRIVATE ${CRITERION_LIBRARY_DIRS})
 
     # Test is registered at the top level in cmake/tests.cmake
+endif()
+
+# Streaming VM test (standalone executable)
+if(BUILD_STREAMING_TEST)
+    add_executable(test_streaming_vm
+        test_streaming.c
+        smollu_vm.c
+    )
+
+    target_include_directories(test_streaming_vm PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    target_compile_definitions(test_streaming_vm PRIVATE
+        CONFIG_SMOLLU_STREAMING=1
+    )
+
+    target_link_libraries(test_streaming_vm
+        m  # Math library
+    )
+
+    # Copy demo bytecode for testing
+    add_custom_command(TARGET test_streaming_vm POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/vm/test_data
+        COMMENT "Creating test data directory"
+    )
 endif()

--- a/vm/smollu_vm.h
+++ b/vm/smollu_vm.h
@@ -59,6 +59,15 @@ typedef Value (*NativeFn)(Value *args, uint8_t argc);
 #define SMOLLU_STACK_MAX 255
 #define SMOLLU_CALLSTACK_MAX 64
 
+/* Streaming cache size configuration */
+#ifndef SMOLLU_STREAM_CACHE_SIZE
+  #ifdef CONFIG_SMOLLU_STREAM_CACHE_SIZE
+    #define SMOLLU_STREAM_CACHE_SIZE CONFIG_SMOLLU_STREAM_CACHE_SIZE
+  #else
+    #define SMOLLU_STREAM_CACHE_SIZE 2048  /* Default 2KB cache */
+  #endif
+#endif
+
 typedef struct {
     uint32_t    ret_pc;
     uint8_t     base;      /* base index in the value stack */
@@ -87,6 +96,18 @@ typedef struct {
     /* Environment */
     Value     globals[256];
     NativeFn  natives[256];
+
+#ifdef CONFIG_SMOLLU_STREAMING
+    /* Streaming source (when bytecode == NULL) */
+    void *stream_ctx;                              /* Context for read_region callback */
+    int (*read_region)(void *ctx, uint32_t offset, uint8_t *dst, size_t len);
+    uint32_t code_offset;                          /* Offset in source where code starts */
+
+    /* Bytecode cache */
+    uint8_t  cache[SMOLLU_STREAM_CACHE_SIZE];      /* Cache buffer */
+    uint32_t cache_start;                          /* PC value at cache start */
+    uint16_t cache_len;                            /* Valid bytes in cache */
+#endif
 } SmolluVM;
 
 /* ────────────────────────────────────────────────────────────────────────── */
@@ -99,6 +120,22 @@ void smollu_vm_load(SmolluVM *vm, const uint8_t *bytecode, size_t len);
 void smollu_vm_register_native(SmolluVM *vm, uint8_t nat_id, NativeFn fn);
 int  smollu_vm_run(SmolluVM *vm);
 void smollu_vm_destroy(SmolluVM *vm);
+
+#ifdef CONFIG_SMOLLU_STREAMING
+/**
+ * @brief Prepare VM for streaming execution from external source (e.g., MRAM)
+ *
+ * @param vm Pointer to VM instance
+ * @param read_region Callback to read data from source: (ctx, offset, dst, len) -> error_code
+ * @param ctx Context pointer passed to read_region callback
+ * @param native_table Array of native function pointers for mapping
+ * @return 0 on success, negative error code on failure
+ */
+int smollu_vm_prepare_streaming(SmolluVM *vm,
+                                int (*read_region)(void *ctx, uint32_t offset, uint8_t *dst, size_t len),
+                                void *ctx,
+                                const NativeFn *native_table);
+#endif
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/vm/test_streaming.c
+++ b/vm/test_streaming.c
@@ -1,0 +1,139 @@
+/**
+ * @file test_streaming.c
+ * @brief Test program for VM streaming mode
+ */
+
+#define CONFIG_SMOLLU_STREAMING 1
+
+#include "smollu_vm.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Simulated streaming source (file-backed)                                  */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+typedef struct {
+    FILE *fp;
+    size_t base_offset;  /* Base offset in file */
+} file_stream_ctx_t;
+
+/**
+ * @brief Read region callback for file-based streaming
+ */
+static int file_read_region(void *ctx, uint32_t offset, uint8_t *dst, size_t len) {
+    file_stream_ctx_t *fctx = (file_stream_ctx_t *)ctx;
+
+    /* Seek to offset */
+    if (fseek(fctx->fp, fctx->base_offset + offset, SEEK_SET) != 0) {
+        fprintf(stderr, "fseek failed for offset %u\n", offset);
+        return -1;
+    }
+
+    /* Read data */
+    size_t bytes_read = fread(dst, 1, len, fctx->fp);
+    if (bytes_read != len) {
+        fprintf(stderr, "Read failed: expected %zu bytes, got %zu\n", len, bytes_read);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Sample native functions                                                   */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+Value nat_print(Value *args, uint8_t argc) {
+    for (uint8_t i = 0; i < argc; ++i) {
+        Value v = args[i];
+        switch (v.type) {
+            case VAL_NIL:   printf("nil"); break;
+            case VAL_BOOL:  printf(v.as.boolean ? "true" : "false"); break;
+            case VAL_INT:   printf("%d", v.as.i); break;
+            case VAL_FLOAT: printf("%f", v.as.f); break;
+        }
+        if (i + 1 < argc) printf(" ");
+    }
+    printf("\n");
+    return value_make_nil();
+}
+
+Value nat_rand(Value *args, uint8_t argc) {
+    (void)argc;
+    if (argc == 0 || args[0].type != VAL_INT) return value_from_int(0);
+    int limit = args[0].as.i;
+    return value_from_int(rand() % (limit ? limit : 1));
+}
+
+/* Native function table */
+static const NativeFn native_table[] = {
+    nat_print,  /* 0 */
+    nat_rand,   /* 1 */
+};
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/*  Main test                                                                 */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+int main(int argc, char **argv) {
+    const char *filename = "demo.smolbc";
+
+    if (argc > 1) {
+        filename = argv[1];
+    }
+
+    printf("=== Smollu VM Streaming Mode Test ===\n");
+    printf("Testing with bytecode file: %s\n\n", filename);
+
+    /* Open bytecode file */
+    FILE *fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "Failed to open bytecode file: %s\n", filename);
+        return -1;
+    }
+
+    /* Setup streaming context */
+    file_stream_ctx_t stream_ctx = {
+        .fp = fp,
+        .base_offset = 0
+    };
+
+    /* Initialize VM */
+    SmolluVM vm;
+    smollu_vm_init(&vm);
+
+    /* Prepare VM in streaming mode */
+    printf("Initializing VM in streaming mode...\n");
+    int ret = smollu_vm_prepare_streaming(&vm, file_read_region, &stream_ctx, native_table);
+    if (ret != 0) {
+        fprintf(stderr, "Failed to prepare streaming VM: %d\n", ret);
+        fclose(fp);
+        return -1;
+    }
+
+    printf("VM initialized successfully\n");
+    printf("  Code size: %u bytes\n", vm.code_size);
+    printf("  Code offset: %u\n", vm.code_offset);
+    printf("  Native count: %u\n", vm.native_count);
+    printf("  Cache size: %d bytes\n\n", SMOLLU_STREAM_CACHE_SIZE);
+
+    /* Run program */
+    printf("Running program...\n");
+    printf("----------------------------------------\n");
+    ret = smollu_vm_run(&vm);
+    printf("----------------------------------------\n");
+
+    if (ret == 0) {
+        printf("\n[SUCCESS] Program terminated normally\n");
+    } else {
+        printf("\n[ERROR] Program terminated with error code %d\n", ret);
+    }
+
+    /* Cleanup */
+    smollu_vm_destroy(&vm);
+    fclose(fp);
+
+    return ret;
+}


### PR DESCRIPTION
- Introduced a new `reload_cache` function to manage bytecode caching during streaming.
- Created a `test_streaming.c` file to test the streaming capabilities with a simulated file-backed source.
- Updated CMake configuration to include options for building streaming tests and ensure bytecode compilation.